### PR TITLE
Fix formatting & grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Markdown CheatSheet
-![markDown](https://camo.githubusercontent.com/a8e78444101b56ee75b4f2752e9616aef78a14a8174aa075d580585346a6b437/687474703a2f2f7061642e6861726f6f70726573732e636f6d2f646f63732f656e2f6d61726b646f776e2d646f632d6c6f676f732f696d616765732f6d61726b646f776e2e706e67)
+<img
+    src="https://camo.githubusercontent.com/a8e78444101b56ee75b4f2752e9616aef78a14a8174aa075d580585346a6b437/687474703a2f2f7061642e6861726f6f70726573732e636f6d2f646f63732f656e2f6d61726b646f776e2d646f632d6c6f676f732f696d616765732f6d61726b646f776e2e706e67" 
+     alt="Markdown"
+     width="100"
+/>
+<!-- HTML elements can be used inside of Markdown, as seen above. -->
 
 ## Text styling
 
@@ -19,21 +24,22 @@
 
 This is normal text.
 
+---
 
+This is  `**bold**`  from wrapping the text with double asterisks.
 
-This is  `**bold**`  by wrapping the text with double asterisk.
+This is **bold** from wrapping the text with double asterisks.
 
-This is **bold** by wrapping the text with double asterisk.
+---
 
+This is `_italic_` from wrapping the text with an underscore.
 
+This is _italic_ from wrapping the text with an underscore.
 
-This is` _italic_` by wrapping the text with single underscores.
+---
 
-This is _italic_ text.
+Wrapping the text with double tildes makes a strikethrough.
 
-
-
-Wrapping the text with double Tilda's would make a strikethrough.
 `~~This is my first idea.~~`
 
 ~~This is my first idea.~~
@@ -50,22 +56,23 @@ This is a [website](google.com) link.
 
 ## Adding Image
 
-It's similar to adding links, the only difference is that it starts with an exclamatory symbol.
-`![NameIfImageCannotBeDisplayed](/Images/GitHub_Logo_White.png)`
+It's similar to adding links, but the only difference is that it starts with an exclamation mark (`!`). Additionally, the text enclosed in square brackets (`[ ]`) is the alt text that is shown in place of the image when it can't be displayed. It should describe what is seen in the photo.
 
-![Shubham](/Images/GitHub_Logo_White.png)
+`![The GitHub Logo](/Images/GitHub_Logo_White.png)`
+
+![The GitHub Logo](/Images/GitHub_Logo_White.png)
 
 ## Lists
 
-To create an unordered list use the '-' symbol.
+To create an unordered list, use the `-` or `*` symbol.
 
 `- List 1`
 
-`- List 2`
+`* List 2`
 
 - List 1
 
-- List 2
+* List 2
 
 To create an ordered list, just add the list in numbered format.
 
@@ -92,13 +99,14 @@ To create an ordered list, just add the list in numbered format.
 - item 3
 
 ### Check List
+
 ```
 - [ ] item 1
-- [ ] item 2
+- [x] item 2
 - [ ] item 3
 ```
 - [ ] item 1
-- [ ] item 2
+- [x] item 2
 - [ ] item 3
 
 ## Table
@@ -113,26 +121,28 @@ To create an ordered list, just add the list in numbered format.
 | :------------- | :------------: | -------------: |
 | row 1 column 1 | row 1 column 2 | row 1 column 3 |
 
-Note :
+**Note:**
 
 - The colon below heading 1 is on the left to ensure the column text is left aligned.
+- The two colons below haeding 2 are on both sides to ensure the column text is centered.
 - The colon below heading 3 is on the right to ensure the column text is right aligned.
-- You can't have a list inside a table, (but you can use some HTML to figure it out).
+- You can't have a list inside a table (but you can use some HTML to figure it out).
 
 ## Code
 
 ### Inline Code
 
 ```markdown
-This is inline code `const name = 'Shubham';`, we use Backticks.
+This is inline code: `const name = 'Shubham';`. We use bacticks.
 ```
 
-This is inline code `const name = 'Shubham';`
+This is inline code: `const name = 'Shubham';`. We use backticks.
 
 ### Block of code
 
-We make use of three Backtick's to wrap a block of code.
-For syntax highlighting add the name of programming language you are using right after the first three Backtick's.
+We make use of three bacticks to wrap a block of code.
+For syntax highlighting, add the name of programming language you are using right after the first three bacticks, followed by a new line.
+The name of the language can be abbreviated in some occasions (for example, both `js` and `javascript` can be used to describe JavaScript code).
 
 ````
 ```js
@@ -154,8 +164,10 @@ sayHello(name);
 
 ### Before and After in Code
 
-Let's say you change a line in the block of code and you want to display it accordingly, to do that you can simply use the 'diff' after the first three Backticks.
-Add '-' before the line of code that you want to change.
+Let's say you change a line in the block of code and you want to display it accordingly. To do that you can simply use the 'diff' after the first three backticks.
+
+Add '-' before the line of code that you want to change or delete.
+
 Add '+' before the new line of code you want to add.
 
 ````
@@ -170,12 +182,11 @@ const lastName = 'Kadam';
 - const firstName = 'Shubham';
 + const firstName = 'Divyanshi';
 const lastName = 'Kadam';
-
 ```
 
 ### Quotes
 
-Use '>' to create a quote, the quote is more like a question and the answer can be in a simple text as shown below.
+Use '>' to create a quote. The quote is more like a question and the answer and can be in a simple text as shown below.
 
 ```markdown
 > I think we should go with option 1 of create a website
@@ -186,19 +197,27 @@ Use '>' to create a quote, the quote is more like a question and the answer can 
 Great Idea, this discussion was really useful. I will go ahead and do it.
 
 ### Comments
+Comments span multiple lines and are invisible in the viewer, but can be seen in the editor. They are the same as HTML comments.
 
-<!-- This is a comment -->
+`<!-- This is a comment -->`
+
+```
+<!--
+    This is a
+    multi-line comment
+-->
+```
 
 ### Collapsible content
 
 ```markdown
 <details>
-      <summary>Click for for information</summary>
+      <summary>Click for more information</summary>
       This is more description...
 </details>
 ```
 
 <details>
-      <summary>Click for for information</summary>
+      <summary>Click for more information</summary>
       This is more description...
 </details>


### PR DESCRIPTION
This is a single commit that fixes some formatting issues and errors with grammar. The most notable changes are:

- Changed the Markdown logo to be smaller as it took up too much space in its default size. It was replaced with an html `<img>` element.
- Added dividers (`---`) between the inline-formatting rules in the beginning of the document in order to separate them for readability.
- Reworded some sentences to make them clearer and uncapitalized words that are not proper nouns (e.g. ~~B~~backticks).
- Added additional information in some areas.
  - An asterisk (`*`) can also be used instead of a (`-`) for unordered lists.
  - Information on the role of alt text in images was added.
  - Checked off one of the items in the checklist example to demonstrate how marking tasks as finished is done.
  - Added information on why the second column in the table had two colons.
  - Elaborated a bit on language codes in the code block section.
  - Added information to the comments section as, due to the nature of comments, it is empty in the viewer.
- Added visible newlines (two newlines in editor) between some paragraphs that required them.

I hope it is not too much to digest.